### PR TITLE
improved build to track package version number

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,5 +1,14 @@
 #!/bin/bash
 
+## sed to get v number and pkg name
+v=$(sed -n 's/Version: //p' DESCRIPTION)
+pkg=$(sed -n 's/Package: //p' DESCRIPTION)
+
+## build the R package
 R CMD build .
-mv rpdd_*.tar.gz docker/assets
-docker build -t rpdd docker
+
+## move the pkg tar to assets dir with version-less name
+mv ${pkg}_${v}.tar.gz docker/assets/${pkg}.tar.gz
+
+## build the image and tag with version *and* latest
+docker build -t ${pkg}:${v} -t ${pkg}:latest docker

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,10 +1,8 @@
 FROM alpine:3.15
 
-ARG VERSION="0.1.0"
-
 ADD assets /assets
 
 RUN apk update && apk add --no-cache R
-RUN Rscript -e "install.packages('/assets/rpdd_${VERSION}.tar.gz', type='source', repos=NULL)"
+RUN Rscript -e "install.packages('/assets/rpdd.tar.gz', type='source', repos=NULL)"
 
 CMD ["/assets/rpdd.sh"]


### PR DESCRIPTION
@stephenturner these changes should do the following:

1) pull out version number and package name from DESCRIPTION (getting name allows this to be used in other repos arbitrarily)
2) build the package based on env vars from ^
3) move the package to a generic (version-less) tar file (that way you don't need to track version ARG in Dockerfile)
4) build and tag image with appropriate version *and* "latest"